### PR TITLE
Add benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,44 @@ Examples using GenMetrics to collect and report runtime metrics for GenStage app
 
 All of these GenStage example applications are clones of the example applications provided in the [GenStage](http://github.com/elixir-lang/gen_stage) project repository.
 
+
+## Benchmarks
+
+Some of you may be curious about the performance impact `gen_metrics` has on the servers and pipelines it is observing, so we've put together a couple of benchmarks to compare the overhead of traced vs untraced servers and pipelines. You can tweak and run the benchmark yourself under `bench/bench.exs`, and simply run `mix bench` to execute them.
+
+The most recent run of the benchmark produced the following report. This benchmark was run on a 2016 Macbook Pro (2.5ghz i7, 16GB RAM, SSD):
+
+```
+Elixir 1.4.1
+Erlang 19.2
+Benchmark suite executing with the following configuration:
+warmup: 5.0s
+time: 30.0s
+parallel: 1
+inputs: none specified
+Estimated total run time: 140.0s
+
+Benchmarking traced pipeline...
+Benchmarking traced server (call)...
+Benchmarking untraced pipeline...
+Benchmarking untraced server (call)...
+
+Name                             ips        average  deviation         median
+untraced server (call)          0.30         3.33 s    ±12.65%         3.08 s
+traced server (call)           0.140         7.16 s     ±8.54%         7.31 s
+untraced pipeline             0.0722        13.84 s     ±8.75%        14.16 s
+traced pipeline               0.0428        23.37 s     ±1.27%        23.37 s
+
+Comparison:
+untraced server (call)          0.30
+traced server (call)           0.140 - 2.15x slower
+untraced pipeline             0.0722 - 4.16x slower
+traced pipeline               0.0428 - 7.02x slower
+```
+
+While the benchmark *is* a contrived scenario (pushing 1M large messages through a `GenServer`, then the same through a `GenStage` pipeline),
+it should reflect a general idea of what you can expect from a performance perspective.
+
 ## License
 
 See the [LICENSE](LICENSE) file for license rights and limitations (Apache License 2.0).

--- a/bench/bench.exs
+++ b/bench/bench.exs
@@ -1,0 +1,60 @@
+Code.require_file("server.exs", "./bench/support")
+Code.require_file("stages.exs", "./bench/support")
+Application.ensure_all_started(:gen_metrics)
+
+data = Enum.map(1..1_000_000, fn i -> %{id: i, data: String.duplicate("a", 100)} end)
+
+{:ok, _traced} = TracedServer.start_link()
+{:ok, _untraced} = UntracedServer.start_link()
+
+alias GenMetrics.GenServer.Cluster
+cluster = %Cluster{name: "bench",
+                   servers: [TracedServer],
+                   opts: [window_interval: 1000]}
+GenMetrics.monitor_cluster(cluster)
+
+{:ok, _tracedp} = TracedProducer.start_link()
+{:ok, _tracedc} = TracedConsumer.start_link()
+{:ok, _untracedp} = UntracedProducer.start_link()
+{:ok, _untracedc} = UntracedConsumer.start_link()
+
+alias GenMetrics.GenStage.Pipeline
+pipeline = %Pipeline{name: "bench2",
+                     producer: [TracedProducer],
+                     consumer: [TracedConsumer],
+                     opts: [statistics: true]}
+
+{:ok, _pid} = GenMetrics.monitor_pipeline(pipeline)
+
+Benchee.run(%{time: 30, warmup: 5}, %{
+      "untraced server (call)" => fn ->
+          for %{id: id} = item <- data do
+            {:ok, ^id} = UntracedServer.do_call(item)
+          end
+      end,
+      "traced server (call)" => fn ->
+        for %{id: id} = item <- data do
+          {:ok, ^id} = TracedServer.do_call(item)
+        end
+      end,
+      "untraced pipeline" => fn ->
+        for %{id: id} = item <- data do
+          {:ok, ^id} = UntracedProducer.emit(item)
+        end
+        for i <- 1..length(data) do
+          receive do
+            ^i -> :ok
+          end
+        end
+      end,
+      "traced pipeline" => fn ->
+        for %{id: id} = item <- data do
+          {:ok, ^id} = TracedProducer.emit(item)
+        end
+        for i <- 1..length(data) do
+          receive do
+            ^i -> :ok
+          end
+        end
+      end
+})

--- a/bench/support/server.exs
+++ b/bench/support/server.exs
@@ -1,0 +1,37 @@
+defmodule TracedServer do
+  use GenServer
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+  def init(_) do
+    {:ok, nil}
+  end
+
+  def do_call(item) do
+    GenServer.call(__MODULE__, {:do_call, item})
+  end
+
+  def handle_call({:do_call, %{id: id}}, _from, state) do
+    {:reply, {:ok, id}, state}
+  end
+end
+
+defmodule UntracedServer do
+  use GenServer
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+  def init(_) do
+    {:ok, nil}
+  end
+
+  def do_call(item) do
+    GenServer.call(__MODULE__, {:do_call, item})
+  end
+
+  def handle_call({:do_call, %{id: id}}, _from, state) do
+    {:reply, {:ok, id}, state}
+  end
+end

--- a/bench/support/stages.exs
+++ b/bench/support/stages.exs
@@ -1,0 +1,97 @@
+defmodule TracedProducer do
+  use GenStage
+
+  def start_link do
+    GenStage.start_link(__MODULE__, [], name: __MODULE__)
+  end
+  def init(_) do
+    {:producer, {:queue.new, 0}}
+  end
+
+  def emit(item) do
+    GenStage.call(__MODULE__, {:emit, item})
+  end
+
+  def handle_call({:emit, item}, {pid, _ref} = from, {queue, demand}) do
+    event = Map.put(item, :pid, pid)
+    dispatch_events(:queue.in({from, event}, queue), demand, [])
+  end
+  def handle_demand(incoming_demand, {queue, demand}) do
+    dispatch_events(queue, incoming_demand + demand, [])
+  end
+
+  defp dispatch_events(queue, demand, events) do
+    with d when d > 0 <- demand,
+         {{:value, {from, event}}, queue} <- :queue.out(queue) do
+      GenStage.reply(from, {:ok, event.id})
+      dispatch_events(queue, demand - 1, [event | events])
+    else
+      _ -> {:noreply, Enum.reverse(events), {queue, demand}}
+    end
+  end
+end
+
+defmodule TracedConsumer do
+  use GenStage
+
+  def start_link do
+    GenStage.start_link(__MODULE__, [], name: __MODULE__)
+  end
+  def init(_) do
+    {:consumer, nil, subscribe_to: [{TracedProducer, max_demand: 1}]}
+  end
+
+  def handle_events([%{id: id, pid: pid} | _], _from, state) do
+    send(pid, id)
+    {:noreply, [], state}
+  end
+end
+
+defmodule UntracedProducer do
+  use GenStage
+
+  def start_link do
+    GenStage.start_link(__MODULE__, [], name: __MODULE__)
+  end
+  def init(_) do
+    {:producer, {:queue.new, 0}}
+  end
+
+  def emit(item) do
+    GenStage.call(__MODULE__, {:emit, item})
+  end
+
+  def handle_call({:emit, item}, {pid, _ref} = from, {queue, demand}) do
+    event = Map.put(item, :pid, pid)
+    dispatch_events(:queue.in({from, event}, queue), demand, [])
+  end
+  def handle_demand(incoming_demand, {queue, demand}) do
+    dispatch_events(queue, incoming_demand + demand, [])
+  end
+
+  defp dispatch_events(queue, demand, events) do
+    with d when d > 0 <- demand,
+         {{:value, {from, event}}, queue} <- :queue.out(queue) do
+      GenStage.reply(from, {:ok, event.id})
+      dispatch_events(queue, demand - 1, [event | events])
+    else
+      _ -> {:noreply, Enum.reverse(events), {queue, demand}}
+    end
+  end
+end
+
+defmodule UntracedConsumer do
+  use GenStage
+
+  def start_link do
+    GenStage.start_link(__MODULE__, [], name: __MODULE__)
+  end
+  def init(_) do
+    {:consumer, nil, subscribe_to: [{UntracedProducer, max_demand: 1}]}
+  end
+
+  def handle_events([%{id: id, pid: pid} | _], _from, state) do
+    send(pid, id)
+    {:noreply, [], state}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule GenMetrics.Mixfile do
      description: description(),
      package: package(),
      deps: deps(),
+     aliases: aliases(),
      docs: [main: "GenMetrics", source_url: "https://github.com/onetapbeyond/gen_metrics"]]
   end
 
@@ -35,7 +36,12 @@ defmodule GenMetrics.Mixfile do
     [{:gen_stage, "~> 0.11"},
      {:statix, ">= 0.0.0"},
      {:ex_doc, "~> 0.14", only: :dev, runtime: false},
-     {:credo, "~> 0.7", only: [:dev, :test]}]
+     {:credo, "~> 0.7", only: [:dev, :test]},
+     {:benchee, "~> 0.7", only: :dev}]
+  end
+
+  defp aliases do
+    [bench: "run ./bench/bench.exs"]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
-  "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+%{"benchee": {:hex, :benchee, "0.7.0", "98e4ed2c86b633df9b0190d6b3bf38bc2e385ba6200f68201fb575d39909816c", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_statsd": {:hex, :ex_statsd, "0.5.3", "e86dd97e25dbc80786e7d22b3c5537f2052a7e12daaaa7e6f2b9c34d03dbbd44", [:mix], []},
-  "gen_stage": {:hex, :gen_stage, "0.11.0", "943bdfa85c75fa624e0a36a9d135baad20a523be040178f5a215444b45c66ea4", [:mix], []},
-  "statix": {:hex, :statix, "1.0.0", "836c0752ad2b568dcdc9b1e67df0df91ad491ea1e19965ac219a9a0569e7e338", [:mix], []}}
+  "gen_stage": {:hex, :gen_stage, "0.11.0", "943bdfa85c75fa624e0a36a9d135baad20a523be040178f5a215444b45c66ea4", [:mix], [], "hexpm"},
+  "statix": {:hex, :statix, "1.0.0", "836c0752ad2b568dcdc9b1e67df0df91ad491ea1e19965ac219a9a0569e7e338", [:mix], [], "hexpm"}}


### PR DESCRIPTION
See #1 for original request. This PR adds a benchmarks for both servers and pipelines, using a contrived, but not unrealistic scenario (a constant heavy load of largish messages). It should probably be expanded to show the same scenario with small messages to see if the overhead is worse or better.